### PR TITLE
Pin setup-miniconda to Node 24 commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: conda-incubator/setup-miniconda@v2.2.0
+    - uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec
       with:
         python-version: 3.9
         auto-update-conda: true


### PR DESCRIPTION
## Summary
- replace setup-miniconda@v2.2.0 with a pinned upstream main commit
- use commit , which already declares the Node 24 runtime

## Notes
- this is a temporary SHA pin until a released setup-miniconda ref is suitable for use
- intended to keep downstream casadi workflows off deprecated Node 20/16 action runtimes